### PR TITLE
Setup OIDC auth on Shopify

### DIFF
--- a/web/oidc-router.js
+++ b/web/oidc-router.js
@@ -1,0 +1,64 @@
+import {Router} from 'express';
+
+const oidcRouter = Router();
+
+import session from 'express-session'
+import passport from 'passport'
+import OpenIDConnectStrategy from 'passport-openidconnect'
+import connectSQLite from 'connect-sqlite3'
+import { config } from './config.js'
+
+//console.log('config.OIDC_CLIENT_ID', config.OIDC_CLIENT_ID)
+//console.log('config.OIDC_CLIENT_SECRET', config.OIDC_CLIENT_SECRET)
+
+const SQLiteStore = connectSQLite(session);
+const sessionStore = new SQLiteStore({db: 'sessions.sqlite', dir: '.', concurrentDB: true});
+
+passport.use(new OpenIDConnectStrategy({
+  issuer: 'https://login.lescommuns.org/auth/realms/data-food-consortium',
+  authorizationURL: 'https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/auth',
+  tokenURL: 'https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/token',
+  userInfoURL: 'https://login.lescommuns.org/auth/realms/data-food-consortium/protocol/openid-connect/userinfo',
+  clientID: config.OIDC_CLIENT_ID,
+  clientSecret: config.OIDC_CLIENT_SECRET,
+  callbackURL: 'https://remaininlight.eu.ngrok.io/ofn/callback'
+  //scope: [ 'profile' ]
+}, function verify(issuer, profile, cb) {
+  console.log('Passport verify issuer, profile', issuer, profile)
+  return cb(null, profile);
+}));
+
+passport.serializeUser(function(user, cb) {
+  console.log('Passport serializeUser user', user)
+  process.nextTick(function() {
+    cb(null, { id: user.id, username: user.username, name: user.displayName });
+  });
+});
+
+passport.deserializeUser(function(user, cb) {
+  console.log('Passport deserializeUser user', user)
+  process.nextTick(function() {
+    return cb(null, user);
+  });
+});
+
+oidcRouter.get('/login', passport.authenticate('openidconnect'));
+
+oidcRouter.get('/oauth2/redirect', passport.authenticate('openidconnect', {
+  successReturnToOrRedirect: 'http://localhost:3001/',
+  failureRedirect: '/login'
+}));
+
+oidcRouter.post('/logout', function(req, res, next) {
+  req.logout()
+  res.redirect('/ofn')
+});
+
+//oidcRouter.use('/*', session({
+//  secret: 'keyboard cat',
+//  resave: false, // don't save session if unmodified
+//  saveUninitialized: false, // don't create session until something stored
+//  store: sessionStore
+//}));
+
+export {sessionStore, oidcRouter};

--- a/web/package.json
+++ b/web/package.json
@@ -12,9 +12,9 @@
     "node": ">=14.13.1"
   },
   "dependencies": {
-    "@datafoodconsortium/connector": "^1.0.0-alpha.3",
-    "@shopify/app": "3.47.3",
-    "@shopify/cli": "3.47.3",
+    "@datafoodconsortium/connector": "^1.0.0-alpha.4",
+    "@shopify/app": "3.47.5",
+    "@shopify/cli": "3.47.5",
     "@shopify/react-form": "^2.5.0",
     "@shopify/react-hooks": "^3.0.5",
     "@shopify/shopify-app-express": "^1.1.0",


### PR DESCRIPTION
Blocked by Content Security Policy headers from lescommuns.org

```
Refused to frame 'https://login.lescommuns.org/' because an ancestor violates the following Content Security Policy directive: "frame-ancestors 'self'".
```
The OIDC login needs to be displayed within an iframe in order for the Shopify app to authenticate with lescommuns. Is it possible to change the Content Security Policy headers on lescommuns? 

Otherwise we may need to look at opening the auth in a new pop-up window and returning the bearer token to the Shopify app in the original window
