### PR TITLE
141 - Allow product prices to be amended outside of a sales session

### DIFF
--- a/web/frontend/components/ProductsCard.jsx
+++ b/web/frontend/components/ProductsCard.jsx
@@ -55,11 +55,13 @@ export function ProductsCard({ producerProduct, existingProduct }) {
     }
   });
 
-  const handleAddToStore = async () => {
+  const addToStoreOrUpdate = async () => {
     const { title, id: producerProductId } = producerProduct.retailProduct;
 
+    const url = variantsMappingData.existingVariantId ? `/api/products/shopify/${variantsMappingData.existingVariantId}` : '/api/products/shopify';
+
     await createShopifyProduct({
-      url: '/api/products/shopify',
+      url: url,
       fetchInit: {
         method: 'POST',
         headers: {
@@ -84,6 +86,7 @@ export function ProductsCard({ producerProduct, existingProduct }) {
 
       return acc;
     }, 0) || 0;
+
 
   return (
     <Accordion key={producerProduct.retailProduct.title}>
@@ -160,38 +163,66 @@ export function ProductsCard({ producerProduct, existingProduct }) {
       <AccordionDetails>
         <Stack spacing="12px">
           <Stack spacing="12px">
-          <VariantMappingComponent
-                isProductPriceChanged={isProductPriceChanged}
-                setIsProductPriceChanged={setIsProductPriceChanged}
-                setVariantsMappingData={setVariantsMappingData}
-                isCurrentSalesSessionActive={isCurrentSalesSessionActive}
-                producerProductMapping={producerProduct}
-                existingProductVariant={existingProduct?.variants ? existingProduct?.variants[0] : null}
-              />
+            <VariantMappingComponent
+              isProductPriceChanged={isProductPriceChanged}
+              setIsProductPriceChanged={setIsProductPriceChanged}
+              setVariantsMappingData={setVariantsMappingData}
+              isCurrentSalesSessionActive={isCurrentSalesSessionActive}
+              producerProductMapping={producerProduct}
+              existingProductVariant={existingProduct?.variants ? existingProduct?.variants[0] : null}
+            />
           </Stack>
 
-          <Stack
-            direction="row"
-            justifyContent="space-between"
-            sx={{
-              pointerEvents: isProductInStore ? 'none' : 'auto',
-              opacity: isProductInStore ? 0.6 : 1
-            }}
-          >
-            <Button
-              variant="contained"
-              type="button"
-              disabled={
-                createShopifyProductLoading ||
-                isProductInStore ||
-                !variantsMappingData || 
-                !isCurrentSalesSessionActive
-              }
-              onClick={handleAddToStore}
+          {
+            isProductInStore && variantsMappingData?.changed && variantsMappingData?.valid &&
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              sx={{
+                pointerEvents: isCurrentSalesSessionActive ? 'none' : 'auto',
+                opacity: isCurrentSalesSessionActive ? 0.6 : 1
+              }}
             >
-              {createShopifyProductLoading ? 'Loading...' : 'Add to store'}
-            </Button>
-          </Stack>
+              <Button
+                variant="contained"
+                type="button"
+                disabled={
+                  createShopifyProductLoading ||
+                  isCurrentSalesSessionActive
+                }
+                onClick={addToStoreOrUpdate}
+              >
+                {createShopifyProductLoading ? 'Loading...' : 'Save changes'}
+              </Button>
+            </Stack>
+          }
+
+          {!isProductInStore &&
+            <Stack
+              direction="row"
+              justifyContent="space-between"
+              sx={{
+                pointerEvents: isCurrentSalesSessionActive ? 'auto' : 'none',
+                opacity: isCurrentSalesSessionActive ? 1 : 0.6
+              }}
+            >
+              <Button
+                variant="contained"
+                type="button"
+                disabled={
+                  createShopifyProductLoading ||
+                  isProductInStore ||
+                  !variantsMappingData ||
+                  !variantsMappingData.valid ||
+                  !isCurrentSalesSessionActive
+                }
+                onClick={addToStoreOrUpdate}
+              >
+                {createShopifyProductLoading ? 'Loading...' : 'Add to store'}
+              </Button>
+            </Stack>
+          }
+
         </Stack>
       </AccordionDetails>
     </Accordion>

--- a/web/modules/products/controllers/index.js
+++ b/web/modules/products/controllers/index.js
@@ -1,6 +1,7 @@
 import { Router } from 'express';
 import getFDCProducts from './get-fdc-products.js';
 import createShopifyProduct from './create-shopify-product.js';
+import updateShopifyVariant from './update-shopify-variant.js';
 import getShopifyProductById from './get-shopify-product-by-id.js';
 import getProducts from './get-products.js';
 
@@ -10,5 +11,6 @@ products.get('/fdc', getFDCProducts);
 products.get('/shopify/:id', getShopifyProductById);
 products.get('/', getProducts);
 products.post('/shopify', createShopifyProduct);
+products.post('/shopify/:variantId', updateShopifyVariant);
 
 export default products;

--- a/web/modules/products/controllers/update-shopify-variant.js
+++ b/web/modules/products/controllers/update-shopify-variant.js
@@ -1,0 +1,40 @@
+/* eslint-disable function-paren-newline */
+/* eslint-disable object-curly-newline */
+import shopify from '../../../shopify.js';
+import { query } from '../../../database/connect.js';
+
+const updateShopifyVariant = async (req, res) => {
+  try {
+    const { session } = res.locals.shopify;
+    const { variantsMappingData } = req.body;
+
+    const variantId = req.params.variantId
+
+    const variantExists = await query('SELECT * FROM variants WHERE hub_variant_id = $1;', [variantId]);
+
+    if (variantExists.rows.length !== 1) {
+      throw new Error(`Variant ${variantId} doesn't exist`);
+    }
+
+    const existingVariant = new shopify.api.rest.Variant({
+      session
+    });
+    existingVariant.id = variantId;
+    existingVariant.price =  variantsMappingData.price,
+    await existingVariant.saveAndUpdate();
+
+    await query('UPDATE variants SET price = $1, added_value = $2, added_value_method = $3 WHERE hub_variant_id = $4', [variantsMappingData.price, variantsMappingData.addedValue, variantsMappingData.addedValueMethod, variantId]);
+
+    return res.json({
+      success: true
+    });
+  } catch (error) {
+    console.error('Could not update Shopify product', error);
+    return res.status(500).json({
+      success: false,
+      error: error.message
+    });
+  }
+};
+
+export default updateShopifyVariant;


### PR DESCRIPTION
Also, show some information as to why the form is disabled. Either you can't add a product because you're outside of a sales session. Or you can't edit a product because you're inside a sales session! Seemed a bit confusing so thought I'd highlight.

Also fixed a bug, the page was only updating the variant price when you checked the checkbox. So if you checked the checkbox and then changed the price, this wasn't reflected on the backend. Think this is what Simon saw when we were looking at it earlier.