### PR TITLE
re-order query call to update hub db with excess items for variant

### DIFF
--- a/web/webhooks/utils/calculatePackageAndExcessItemsAfterCancelledOrder.js
+++ b/web/webhooks/utils/calculatePackageAndExcessItemsAfterCancelledOrder.js
@@ -24,7 +24,7 @@ export function calculatePackageAndExcessItemsAfterCancelledOrder({
   const numberOfExcessItems = totalExcessItems % noOfItemsPerPackage;
 
   return {
-    numberOfExcessItems,
-    numberOfPackages
+    numberOfExcessItems: Number(numberOfExcessItems),
+    numberOfPackages: Number(numberOfPackages)
   };
 }

--- a/web/webhooks/utils/handleOrderWebhook.js
+++ b/web/webhooks/utils/handleOrderWebhook.js
@@ -7,6 +7,7 @@ import { handleStockAfterOrderUpdate } from './handleStockAfterOrderUpdate.js';
 // TODO move this to utils
 import { updateCurrentVariantInventory } from '../updateCurrentVariantInventory.js';
 import { sendOrderToProducerAndUpdateSalesSessionOrderId } from './sendOrderToProducerAndUpdateSalesSessionOrderId.js';
+import { updateVariantExcessItems } from './updateVariantExcessItems.js';
 
 const selectVariantsQuery = `
 SELECT
@@ -131,8 +132,13 @@ export const handleOrderWebhook = async (
         numberOfExcessItems,
         hubProductId,
         producerProductId
-      }) =>
-        updateCurrentVariantInventory({
+      }) => {
+        await updateVariantExcessItems({
+          numberOfExcessItems,
+          hubVariantId,
+          sqlClient
+        });
+        await updateCurrentVariantInventory({
           storedHubVariant: {
             hubVariantId,
             noOfItemsPerPackage,
@@ -142,7 +148,8 @@ export const handleOrderWebhook = async (
           },
           hubProductId,
           producerProductId
-        })
+        });
+      }
     );
 
     await Promise.allSettled(updateVariantsInventoryPromises);

--- a/web/webhooks/utils/updateVariantExcessItems.js
+++ b/web/webhooks/utils/updateVariantExcessItems.js
@@ -1,0 +1,35 @@
+import { throwError } from '../../utils/index.js';
+import { query } from '../../database/connect.js';
+
+const updateVariantQuery = `
+UPDATE variants
+SET number_of_excess_orders = $1
+WHERE hub_variant_id = $2
+`;
+
+export const updateVariantExcessItems = async ({
+  numberOfExcessItems,
+  hubVariantId,
+  sqlClient
+}) => {
+  try {
+    if (!numberOfExcessItems || !hubVariantId) {
+      throwError(
+        'updateVariantExcessItems: Missing numberOfExcessItems or hubVariantId'
+      );
+    }
+
+    await sqlClient.query('BEGIN');
+    const result = await query(
+      updateVariantQuery,
+      [numberOfExcessItems, hubVariantId],
+      sqlClient
+    );
+    await sqlClient.query('COMMIT');
+
+    return result;
+  } catch (error) {
+    await sqlClient.query('ROLLBACK');
+    throwError('updateVariantExcessItems error from catch', error);
+  }
+};


### PR DESCRIPTION
partly relates https://github.com/yalla-coop/food-data-collaboration/issues/153 by updating the order of when the hub's variant table is being updated depending on if the producer needs to update the ss order