### PR TITLE
#157 fix 

### DIFF
--- a/web/webhooks/utils/handleOrderWebhook.js
+++ b/web/webhooks/utils/handleOrderWebhook.js
@@ -20,6 +20,38 @@ ON v.product_id = p.id
 WHERE hub_variant_id = ANY($1)
 `;
 
+const updateExcessItemsAndInventory = async (variantData, sqlClient) => {
+  const updateExcessItemsPromises = variantData.map(
+    async ({
+      hubVariantId,
+      noOfItemsPerPackage,
+      mappedProducerVariantId,
+      numberOfExcessItems,
+      hubProductId,
+      producerProductId
+    }) => {
+      await updateVariantExcessItems({
+        numberOfExcessItems,
+        hubVariantId,
+        sqlClient
+      });
+      await updateCurrentVariantInventory({
+        storedHubVariant: {
+          hubVariantId,
+          noOfItemsPerPackage,
+          mappedVariantId: mappedProducerVariantId,
+          // TODO rename this to numberOfExcessItems
+          numberOfExcessOrders: numberOfExcessItems
+        },
+        hubProductId,
+        producerProductId
+      });
+    }
+  );
+
+  return Promise.allSettled(updateExcessItemsPromises);
+};
+
 export const handleOrderWebhook = async (
   topic,
   shop,
@@ -62,8 +94,7 @@ export const handleOrderWebhook = async (
         return handleStockAfterOrderUpdate({
           orderType,
           variantFromOrder: v,
-          variantFromDB: singleVariantFromDB,
-          sqlClient
+          variantFromDB: singleVariantFromDB
         });
       })
     );
@@ -80,15 +111,23 @@ export const handleOrderWebhook = async (
         statusCode: 200
       };
     }
+    // update the excess items for variants that were not sent to producer
+    const variantsWithSufficientExcessItems = updatedVariantsData.filter(
+      (v) => Number(v?.numberOfPackages) < 1
+    );
 
-    const wholeSaleVariantsToOrderFromProducer = updatedVariantsData
-      .filter((v) => v.numberOfPackages > 0)
-      .map((v) => ({
-        mappedProducerVariantId: v.mappedProducerVariantId,
-        numberOfPackages: v.numberOfPackages
-      }));
+    if (variantsWithSufficientExcessItems?.length > 0) {
+      await updateExcessItemsAndInventory(
+        variantsWithSufficientExcessItems,
+        sqlClient
+      );
+    }
 
-    if (wholeSaleVariantsToOrderFromProducer.length === 0) {
+    const variantsToOrderFromProducer = updatedVariantsData.filter(
+      (v) => Number(v?.numberOfPackages) > 0
+    );
+
+    if (variantsToOrderFromProducer.length === 0) {
       console.log(
         `handleOrderWebhook: No line items to be sent to producer for sales session: ${activeSalesSessionId}`
       );
@@ -107,7 +146,7 @@ export const handleOrderWebhook = async (
     const { producerRespondSuccess, newProducerOrderId } =
       await sendOrderToProducerAndUpdateSalesSessionOrderId({
         activeSalesSessionOrderId,
-        variants: wholeSaleVariantsToOrderFromProducer,
+        variants: variantsToOrderFromProducer,
         activeSalesSessionId,
         customer,
         orderType,
@@ -123,36 +162,8 @@ export const handleOrderWebhook = async (
       `handleOrderWebhook: Updated sales session with order id ${newProducerOrderId} as received from producer`
     );
 
-    // TODO add sqlClient to updateCurrentVariantInventory
-    const updateVariantsInventoryPromises = updatedVariantsData.map(
-      async ({
-        hubVariantId,
-        noOfItemsPerPackage,
-        mappedProducerVariantId,
-        numberOfExcessItems,
-        hubProductId,
-        producerProductId
-      }) => {
-        await updateVariantExcessItems({
-          numberOfExcessItems,
-          hubVariantId,
-          sqlClient
-        });
-        await updateCurrentVariantInventory({
-          storedHubVariant: {
-            hubVariantId,
-            noOfItemsPerPackage,
-            mappedVariantId: mappedProducerVariantId,
-            // TODO rename this to numberOfExcessItems
-            numberOfExcessOrders: numberOfExcessItems
-          },
-          hubProductId,
-          producerProductId
-        });
-      }
-    );
+    await updateExcessItemsAndInventory(variantsToOrderFromProducer, sqlClient);
 
-    await Promise.allSettled(updateVariantsInventoryPromises);
     console.log(
       'handleOrderWebhook: Updated inventory for variants, all done!'
     );

--- a/web/webhooks/utils/handleStockAfterOrderUpdate.js
+++ b/web/webhooks/utils/handleStockAfterOrderUpdate.js
@@ -2,76 +2,59 @@ import { throwError } from '../../utils/index.js';
 
 import { calculatePackageAndExcessItemsAfterCancelledOrder } from './calculatePackageAndExcessItemsAfterCancelledOrder.js';
 import { calculatePackageAndExcessItemsAfterCompletedOrder } from './calculatePackageAndExcessItemsAfterCompletedOrder.js';
-import { updateVariantExcessItems } from './updateVariantExcessItems.js';
 
 export const handleStockAfterOrderUpdate = async ({
   orderType,
   variantFromOrder,
-  variantFromDB,
-  sqlClient
+  variantFromDB
 }) => {
-  try {
-    if (!orderType) {
-      throwError('handleStockAfterOrderUpdate: Missing orderType');
-    }
-    if (!variantFromOrder || !variantFromDB) {
-      throwError(
-        'handleStockAfterOrderUpdate: Missing variant data from order or DB'
-      );
-    }
-    if (!variantFromOrder?.variantId || !variantFromOrder?.quantity) {
-      throwError('handleStockAfterOrderUpdate: Missing variantId or quantity');
-    }
-
-    const { variantId: hubVariantId, quantity } = variantFromOrder;
-
-    const { hubProductId, producerProductId } = variantFromDB;
-    const mappedProducerVariantId = variantFromDB.mappedVariantId;
-    const noOfItemsPerPackage = Number(variantFromDB.noOfItemsPerPackage);
-    const numberOfExistingExcessItems = Number(
-      variantFromDB.numberOfExcessOrders
-    );
-
-    const currentStockVars = {
-      noOfItemsPerPackage,
-      quantity,
-      numberOfExistingExcessItems
-    };
-    let updatedStockData = null;
-
-    if (orderType === 'cancelled') {
-      updatedStockData =
-        calculatePackageAndExcessItemsAfterCancelledOrder(currentStockVars);
-    } else {
-      updatedStockData =
-        calculatePackageAndExcessItemsAfterCompletedOrder(currentStockVars);
-    }
-
-    const { numberOfExcessItems, numberOfPackages } = updatedStockData;
-    const noCallToProducer = numberOfPackages === 0;
-    // update the hub variant with the new excess items directly if no producer request is sent
-    if (
-      noCallToProducer &&
-      numberOfExistingExcessItems !== numberOfExcessItems
-    ) {
-      await updateVariantExcessItems({
-        numberOfExcessItems,
-        hubVariantId,
-        sqlClient
-      });
-    }
-    const stockData = {
-      noOfItemsPerPackage,
-      numberOfPackages,
-      numberOfExcessItems,
-      mappedProducerVariantId,
-      hubVariantId,
-      hubProductId,
-      producerProductId
-    };
-
-    return stockData;
-  } catch (error) {
-    throwError('handleStockAfterOrderUpdate error from catch', error);
+  if (!orderType) {
+    throwError('handleStockAfterOrderUpdate: Missing orderType');
   }
+  if (!variantFromOrder || !variantFromDB) {
+    throwError(
+      'handleStockAfterOrderUpdate: Missing variant data from order or DB'
+    );
+  }
+  if (!variantFromOrder?.variantId || !variantFromOrder?.quantity) {
+    throwError('handleStockAfterOrderUpdate: Missing variantId or quantity');
+  }
+
+  const { variantId: hubVariantId, quantity } = variantFromOrder;
+
+  const { hubProductId, producerProductId } = variantFromDB;
+  const mappedProducerVariantId = variantFromDB.mappedVariantId;
+  const noOfItemsPerPackage = Number(variantFromDB.noOfItemsPerPackage);
+  const numberOfExistingExcessItems = Number(
+    variantFromDB.numberOfExcessOrders
+  );
+
+  const currentStockVars = {
+    noOfItemsPerPackage,
+    quantity,
+    numberOfExistingExcessItems
+  };
+  let updatedStockData = null;
+
+  if (orderType === 'cancelled') {
+    updatedStockData =
+      calculatePackageAndExcessItemsAfterCancelledOrder(currentStockVars);
+  } else {
+    updatedStockData =
+      calculatePackageAndExcessItemsAfterCompletedOrder(currentStockVars);
+  }
+
+  const { numberOfExcessItems, numberOfPackages } = updatedStockData;
+
+  const stockData = {
+    noOfItemsPerPackage,
+    numberOfPackages,
+    numberOfExcessItems,
+    mappedProducerVariantId,
+    hubVariantId,
+    hubProductId,
+    producerProductId
+  };
+
+  return stockData;
 };

--- a/web/webhooks/utils/updateVariantExcessItems.js
+++ b/web/webhooks/utils/updateVariantExcessItems.js
@@ -13,21 +13,20 @@ export const updateVariantExcessItems = async ({
   sqlClient
 }) => {
   try {
-    if (!numberOfExcessItems || !hubVariantId) {
+    if (numberOfExcessItems === undefined || !hubVariantId) {
       throwError(
         'updateVariantExcessItems: Missing numberOfExcessItems or hubVariantId'
       );
     }
 
     await sqlClient.query('BEGIN');
-    const result = await query(
+    await query(
       updateVariantQuery,
       [numberOfExcessItems, hubVariantId],
       sqlClient
     );
-    await sqlClient.query('COMMIT');
 
-    return result;
+    await sqlClient.query('COMMIT');
   } catch (error) {
     await sqlClient.query('ROLLBACK');
     throwError('updateVariantExcessItems error from catch', error);


### PR DESCRIPTION
relates https://github.com/yalla-coop/food-data-collaboration/issues/157

PR for the issue with orders not updating stock correctly. 

Issues that I found:

1. in the function that should update the excess items in the hub db there was a check that excluded items with a value of 0 meaning that it wasn't running when the new excess items were 0 
2. for the case that a producer didn't need to get informed we weren't calling the update hub inventory function (this would still be called by the minute via the cron job but still)
3. the amount of async operations inside the webhook seems generally pretty broad so i've tried to update the order a little bit to make it reuse a few more things.